### PR TITLE
Use query string to autofill login fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gearscout-collection",
   "private": true,
-  "version": "2025.4.1",
+  "version": "2025.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gearscout-collection",
   "private": true,
-  "version": "2025.4.2",
+  "version": "2025.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/login-page/LoginPage.tsx
+++ b/src/components/login-page/LoginPage.tsx
@@ -10,39 +10,39 @@ interface IProps {
 }
 
 export default function LoginPage(props: IProps) {
-	const query = new URLSearchParams(window.location.search);
-	const initialTeamNumber = query.get('team');
-	const initialEventCode = query.get('event');
-	const initialSecretCode = query.get('secret');
-	const initialTbaCode = query.get('tba');
-
-	if (initialTeamNumber ?? initialEventCode ?? initialSecretCode ?? initialTbaCode) {
-		// set initial values from query string and clear
-		if (initialTeamNumber) {
-			localStorage.setItem('teamNumber', initialTeamNumber);
-		}
-		if (initialEventCode) {
-			localStorage.setItem('eventCode', initialEventCode);
-		}
-		if (initialSecretCode) {
-			localStorage.setItem('secretCode', initialSecretCode);
-		}
-		if (initialTbaCode) {
-			localStorage.setItem('tbaCode', initialTbaCode);
-		}
-		const urlPieces = [location.protocol, '//', location.host, location.pathname];
-		let url = urlPieces.join('');
-		window.location.replace(url);
-	}
-
 	const [teamNumber, setTeamNumber] = useState<string>('');
 	const [scouterName, setScouterName] = useState<string>('');
 	const [eventCode, setEventCode] = useState<string>('');
 	const [secretCode, setSecretCode] = useState<string>('');
 	const [tbaCode, setTbaCode] = useState<string>('');
 
-	// Initialize inputs with last saved values
 	useEffect(() => {
+		const query = new URLSearchParams(window.location.search);
+		const initialTeamNumber = query.get('team');
+		const initialEventCode = query.get('event');
+		const initialSecretCode = query.get('secret');
+		const initialTbaCode = query.get('tba');
+
+		if (initialTeamNumber ?? initialEventCode ?? initialSecretCode ?? initialTbaCode) {
+			// set initial values from query string and clear
+			if (initialTeamNumber) {
+				localStorage.setItem('teamNumber', initialTeamNumber);
+			}
+			if (initialEventCode) {
+				localStorage.setItem('eventCode', initialEventCode);
+			}
+			if (initialSecretCode) {
+				localStorage.setItem('secretCode', initialSecretCode);
+			}
+			if (initialTbaCode) {
+				localStorage.setItem('tbaCode', initialTbaCode);
+			}
+			const urlPieces = [location.protocol, '//', location.host, location.pathname];
+			let url = urlPieces.join('');
+			window.location.replace(url);
+		}
+
+		// Initialize inputs with last saved values
 		setTeamNumber(localStorage.getItem('teamNumber') ?? '');
 		setScouterName(localStorage.getItem('scouterName') ?? '');
 		setEventCode(localStorage.getItem('eventCode') ?? '');

--- a/src/components/login-page/LoginPage.tsx
+++ b/src/components/login-page/LoginPage.tsx
@@ -11,6 +11,30 @@ interface IProps {
 
 export default function LoginPage(props: IProps) {
 	const query = new URLSearchParams(window.location.search);
+	const initialTeamNumber = query.get('team');
+	const initialEventCode = query.get('event');
+	const initialSecretCode = query.get('secret');
+	const initialTbaCode = query.get('tba');
+
+	if (initialTeamNumber ?? initialEventCode ?? initialSecretCode ?? initialTbaCode) {
+		// set initial values from query string and clear
+		if (initialTeamNumber) {
+			localStorage.setItem('teamNumber', initialTeamNumber);
+		}
+		if (initialEventCode) {
+			localStorage.setItem('eventCode', initialEventCode);
+		}
+		if (initialSecretCode) {
+			localStorage.setItem('secretCode', initialSecretCode);
+		}
+		if (initialTbaCode) {
+			localStorage.setItem('tbaCode', initialTbaCode);
+		}
+		const urlPieces = [location.protocol, '//', location.host, location.pathname];
+		let url = urlPieces.join('');
+		window.location.replace(url);
+	}
+
 	const [teamNumber, setTeamNumber] = useState<string>('');
 	const [scouterName, setScouterName] = useState<string>('');
 	const [eventCode, setEventCode] = useState<string>('');
@@ -19,11 +43,11 @@ export default function LoginPage(props: IProps) {
 
 	// Initialize inputs with last saved values
 	useEffect(() => {
-		setTeamNumber(query.get('team') ?? localStorage.getItem('teamNumber') ?? '');
+		setTeamNumber(localStorage.getItem('teamNumber') ?? '');
 		setScouterName(localStorage.getItem('scouterName') ?? '');
-		setEventCode(query.get('event') ?? localStorage.getItem('eventCode') ?? '');
-		setSecretCode(query.get('secret') ?? localStorage.getItem('secretCode') ?? '');
-		setTbaCode(query.get('tba') ?? localStorage.getItem('tbaCode') ?? '');
+		setEventCode(localStorage.getItem('eventCode') ?? '');
+		setSecretCode(localStorage.getItem('secretCode') ?? '');
+		setTbaCode(localStorage.getItem('tbaCode') ?? '');
 	}, []);
 
 	const isValid: boolean = Boolean(

--- a/src/components/login-page/LoginPage.tsx
+++ b/src/components/login-page/LoginPage.tsx
@@ -10,6 +10,7 @@ interface IProps {
 }
 
 export default function LoginPage(props: IProps) {
+	const query = new URLSearchParams(window.location.search);
 	const [teamNumber, setTeamNumber] = useState<string>('');
 	const [scouterName, setScouterName] = useState<string>('');
 	const [eventCode, setEventCode] = useState<string>('');
@@ -18,11 +19,11 @@ export default function LoginPage(props: IProps) {
 
 	// Initialize inputs with last saved values
 	useEffect(() => {
-		setTeamNumber(localStorage.getItem('teamNumber') ?? '');
+		setTeamNumber(query.get('team') ?? localStorage.getItem('teamNumber') ?? '');
 		setScouterName(localStorage.getItem('scouterName') ?? '');
-		setEventCode(localStorage.getItem('eventCode') ?? '');
-		setSecretCode(localStorage.getItem('secretCode') ?? '');
-		setTbaCode(localStorage.getItem('tbaCode') ?? '');
+		setEventCode(query.get('event') ?? localStorage.getItem('eventCode') ?? '');
+		setSecretCode(query.get('secret') ?? localStorage.getItem('secretCode') ?? '');
+		setTbaCode(query.get('tba') ?? localStorage.getItem('tbaCode') ?? '');
 	}, []);
 
 	const isValid: boolean = Boolean(


### PR DESCRIPTION
This PR allows several of the login fields to be set using the query string. For example:

`https://gearitforward.com?team=2338&event=2025ILCH&secret=12345&tba=ILCH`

will autofill the following fields:

![Sun Mar 30 11:48:13 AM CDT 2025](https://github.com/user-attachments/assets/00774440-8fa9-4862-93b3-9653f5088ec7)

# Motivation

I want to be able to share a QR code with scouts that automatically fills most of the login fields for them. This should significantly reduce the amount of mistakes they make in the login process. Putting login info in the query string is the most obvious path to making that happen.

# How it works

All fields are optional - you can use the other fields without setting `secret`, for example.

- `event` sets the event code.
- `team` sets the team number.
- `secret` sets the secret code.
- `tba` sets the TBA code.

# Approach

At first, I tried just pulling from the query string inside the `useEffect()` at the top of `LoginPage()`. This worked, but it resulted in some wacky behavior. Hitting the browser's "back" button after logging in could cause your login info to change, which is very counterintuitive.

So, I abandoned that approach. Now, it checks for the presence of any of the above query string parameters, sets their values in `localStorage`, then refreshes the page, discarding the query string. The result is that hitting the browser's "back" button returns you to the login page, without the possibility of accidentally changing your login info.

The downside is that the app flashes on the screen for a moment before refreshing - but _only_ when query string parameters are provided. Hitting the "back" button in the browser (or the app itself) doesn't cause a flash, since the parameters were cleared on login.